### PR TITLE
Fixed new window opening in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,13 @@ app.on('ready', function()
 	// New window callback
 	page.on('new-window', function(e, url)
 	{
-		mainWindow.loadURL(url);
+		if ( /(.*)\.activecollab\.com/.test(url) ){
+			mainWindow.loadURL(url);	
+		}
+		else{
+			e.preventDefault();
+ 			electron.shell.openExternal(url);
+		}
 	});
 
 });

--- a/index.js
+++ b/index.js
@@ -104,9 +104,7 @@ app.on('ready', function()
 	// New window callback
 	page.on('new-window', function(e, url)
 	{
-		e.preventDefault();
-		electron.shell.openExternal(url);
-
+		mainWindow.loadURL(url);
 	});
 
 });

--- a/index.js
+++ b/index.js
@@ -104,12 +104,14 @@ app.on('ready', function()
 	// New window callback
 	page.on('new-window', function(e, url)
 	{
-		if ( /(.*)\.activecollab\.com/.test(url) ){
+		if (/(.*)\.activecollab\.com/.test(url))
+		{
 			mainWindow.loadURL(url);	
 		}
-		else{
+		else
+		{
 			e.preventDefault();
- 			electron.shell.openExternal(url);
+			electron.shell.openExternal(url);
 		}
 	});
 


### PR DESCRIPTION
In the current version I couldn't choose the active collab account, because after clicking one account the next window was opened up in my default browser. This pull request fixes this quite brutally by opening all "new-window"-urls in the mainWindow.
